### PR TITLE
Add hashbang

### DIFF
--- a/create_mm_audiobin.py
+++ b/create_mm_audiobin.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 import shutil


### PR DESCRIPTION
Scripts should tell shells what interpreter to use via a hashbang.